### PR TITLE
Exclude development stuff from repository autogenerated ZIP archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/examples export-ignore
+/tests export-ignore
+.gitignore export-ignore
+.scrutinizer.yml export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,4 @@
 /examples export-ignore
 /tests export-ignore
-.gitignore export-ignore
-.scrutinizer.yml export-ignore
-.travis.yml export-ignore
-phpunit.xml.dist export-ignore
+/.* export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
People that install this library via composer don't need the test stuff, they just need the library itself.
This PR removes the development directories and files from the repository auto-generated ZIP archives.
Since these development files/directories will still be available via `git clone`, Travis is happy, developers are happy, and so are end-users (they won't have unneeded stuff in production machines).
